### PR TITLE
Some fixes & remove Python lesson goals

### DIFF
--- a/_data/overview.yml
+++ b/_data/overview.yml
@@ -1,14 +1,11 @@
 targets:
-    - sqlite / peewee
-    - os.path / os / pathlib
-    - functools
-    - urllib.request
-    - http / cgi / ssl / hashlib
-    - descriptors
-    - collections
-    - importlib / sys.path
-    - list/dict/generator comprehension
-    - file descriptors
-    - subprocess
-    - threading / multiprocessing
-    - decorators
+    - understanding the structure of a C script
+    - compiling a program
+    - Input/Output of strings and variables
+    - control structures
+    - defining functions
+    - using standard libraries
+    - Arrays
+    - complex data types
+    - Pointers and Pointer logic
+    - dynamic storage

--- a/_exercises/ascii-code-explorer.md
+++ b/_exercises/ascii-code-explorer.md
@@ -4,7 +4,7 @@ number: 2
 status: reviewed
 difficulty: easy
 requirements: variables, input/output
-authors: manuel, richard
+authors: [manuel, richard]
 lesson: 2
 ---
 Write a program that asks to input a character and prints its ASCII code number.

--- a/_exercises/calculator_light.md
+++ b/_exercises/calculator_light.md
@@ -4,7 +4,7 @@ number: 3
 status: reviewed
 difficulty: easy
 requirements: input/output, operators
-authors: manuel, richard
+authors: [manuel, richard]
 lesson: 2
 ---
 Write a program that asks the user for two decimal numbers and prints their sum, difference, product, integer quotient and remainder.

--- a/_exercises/geometry.md
+++ b/_exercises/geometry.md
@@ -4,7 +4,7 @@ number: 4
 status: reviewed
 difficulty: easy
 requirements: input/output, all kinds of operators
-authors: manuel, richard
+authors: [manuel, richard]
 lesson: 3
 ---
 Write a program that asks for a radius and calculates the area of the corresponding circle. (Let's assume pi == 3.14).

--- a/_exercises/hello-again.md
+++ b/_exercises/hello-again.md
@@ -4,10 +4,9 @@ number: 1
 status: reviewed
 difficulty: easy
 requirements: variables, input/output
-authors: manuel, richard
+authors: [manuel, richard]
 lesson: 2
 ---
 Write a program that prints the String "Hello World!" on the command line, using only placeholders in the format string.
 
 **Experts:** In leetspeek you say "H3110 W0$|$21d!". Use actual numbers.
-


### PR DESCRIPTION
I fixed the authors names not being displayed correctly (they need to be put in a list) and replaced the old lesson goals from python with the goals of the C-course.
