### PR TITLE
added caution slide, maybe wrong position?

### DIFF
--- a/latex/slides/03_control_structures_1.tex
+++ b/latex/slides/03_control_structures_1.tex
@@ -158,6 +158,20 @@ else
 \end{lstlisting}
 	\end{columns}
 \end{frame}
+\begin{frame}[fragile]{Caution}
+	A condition will only be evaluated until it's result is definitive.
+	\begin{itemize}
+	\item \&\& will only be evaluated until one condition is false.
+	\item $||$ will only be evaluated until one condition is true.
+	\end{itemize}
+	\begin{lstlisting}[numbers=none]
+int a = 10;
+int c;
+if(a == 10 || (a = c)){ //evaluates to true, but c is undefined
+	...	
+}
+\end{lstlisting} 
+\end{frame}
 \begin{frame}[fragile]{switch}
 	If you have to check one variable for many constant values, \textit{switch case} is your friend:
 	\begin{lstlisting}[numbers=none,basicstyle=\itshape\footnotesize]


### PR DESCRIPTION
The build works for me now. Maybe it would be better to use another example (e.g. increment using ++ operator or a function call). 

We couldn't decide whether it would be better to mention it at this point or in the fifth lesson, when functions are introduced.
